### PR TITLE
Emissions plots

### DIFF
--- a/rl_fyp/gym_rsu/script.py
+++ b/rl_fyp/gym_rsu/script.py
@@ -122,11 +122,11 @@ elif argumentList.__len__() is 4:
             # model = PPO2.load(
             #     (f'rsu_agents/single_lane_highway_agents/optimized_interval/PPO2_ns3_single_lane_highway_cars=25_optimized'))
 
-            model = SAC.load(
-                (f'rsu_agents/single_lane_highway_agents/optimized_interval/SAC_ns3_single_lane_highway_cars=25_optimized'))
+            # model = SAC.load(
+            #     (f'rsu_agents/single_lane_highway_agents/optimized_interval/SAC_ns3_single_lane_highway_cars=25_optimized'))
 
-            # model = TD3.load(
-            #     f'rsu_agents/single_lane_highway_agents/optimized_interval/TD3_ns3_single_lane_highway_cars=25_optimized')
+            model = TD3.load(
+                f'rsu_agents/single_lane_highway_agents/optimized_interval/TD3_ns3_single_lane_highway_cars=25_optimized')
 
             # model = PPO2.load(
             #     (f'rsu_agents/square_agents/optimized_interval/PPO2_ns3_square_cars=25_optimized'))

--- a/rl_fyp/gym_rsu/script.py
+++ b/rl_fyp/gym_rsu/script.py
@@ -122,11 +122,11 @@ elif argumentList.__len__() is 4:
             # model = PPO2.load(
             #     (f'rsu_agents/single_lane_highway_agents/optimized_interval/PPO2_ns3_single_lane_highway_cars=25_optimized'))
 
-            # model = SAC.load(
-            #     (f'rsu_agents/single_lane_highway_agents/optimized_interval/SAC_ns3_single_lane_highway_cars=25_optimized'))
+            model = SAC.load(
+                (f'rsu_agents/single_lane_highway_agents/optimized_interval/SAC_ns3_single_lane_highway_cars=25_optimized'))
 
-            model = TD3.load(
-                f'rsu_agents/single_lane_highway_agents/optimized_interval/TD3_ns3_single_lane_highway_cars=25_optimized')
+            # model = TD3.load(
+            #     f'rsu_agents/single_lane_highway_agents/optimized_interval/TD3_ns3_single_lane_highway_cars=25_optimized')
 
             # model = PPO2.load(
             #     (f'rsu_agents/square_agents/optimized_interval/PPO2_ns3_square_cars=25_optimized'))

--- a/rl_fyp/ns3_logs/plot_vehicle_data.py
+++ b/rl_fyp/ns3_logs/plot_vehicle_data.py
@@ -31,6 +31,12 @@ speeds_avg = {}
 speeds_std = {}
 headways_avg = {}
 headways_std = {}
+fuel_consumption_avg = {}
+co2_emission_avg = {}
+co_emission_avg = {}
+nox_emission_avg = {}
+pmx_emission_avg = {}
+hc_emission_avg = {}
 
 
 with open(rsu_data_file, 'r') as f:
@@ -38,20 +44,60 @@ with open(rsu_data_file, 'r') as f:
     time = 0
     speeds = []
     headways = []
+    fuel_consumption = []
+    co2_emission = []
+    co_emission = []
+    nox_emission = []
+    pmx_emission = []
+    hc_emission = []
+
     try:
         while line:
             if "time" in line:
                 if time > 0:
+                    # save speeds mean and std
                     speeds_avg[time] = 0 if len(
                         speeds) < 1 else statistics.mean(speeds)
                     speeds_std[time] = 0 if len(
                         speeds) < 2 else statistics.stdev(speeds)
+                    speeds = []
+
+                    # save headways mean and std
                     headways_avg[time] = 0 if len(
                         headways) < 1 else statistics.mean(headways)
                     headways_std[time] = 0 if len(
                         headways) < 2 else statistics.stdev(headways)
-                    speeds = []
                     headways = []
+
+                    # save fuel consumption mean
+                    fuel_consumption_avg[time] = 0 if len(
+                        fuel_consumption) < 1 else statistics.mean(fuel_consumption)
+                    fuel_consumption = []
+
+                    # save CO2 emission mean
+                    co2_emission_avg[time] = 0 if len(
+                        co2_emission) < 1 else statistics.mean(co2_emission)
+                    co2_emission = []
+
+                    # save CO emission mean
+                    co_emission_avg[time] = 0 if len(
+                        co_emission) < 1 else statistics.mean(co_emission)
+                    co_emission = []
+
+                    # save NOx emission mean
+                    nox_emission_avg[time] = 0 if len(
+                        nox_emission) < 1 else statistics.mean(nox_emission)
+                    nox_emission = []
+
+                    # save PMx mean
+                    pmx_emission_avg[time] = 0 if len(
+                        nox_emission) < 1 else statistics.mean(pmx_emission)
+                    pmx_emission = []
+
+                    # save hc mean
+                    hc_emission_avg[time] = 0 if len(
+                        hc_emission) < 1 else statistics.mean(hc_emission)
+                    hc_emission = []
 
                 time = float(line[line.find("=")+1: line.find(":")].strip())
 
@@ -60,6 +106,12 @@ with open(rsu_data_file, 'r') as f:
                 if len(vals) > 1:
                     speeds.append(float(vals[1].strip()))
                     headways.append(float(vals[2].strip()))
+                    fuel_consumption.append(float(vals[3].strip()))
+                    co2_emission.append(float(vals[4].strip()))
+                    co_emission.append(float(vals[5].strip()))
+                    nox_emission.append(float(vals[6].strip()))
+                    pmx_emission.append(float(vals[7].strip()))
+                    hc_emission.append(float(vals[8].strip()))
 
             line = f.readline()
 
@@ -72,8 +124,9 @@ with open(rsu_data_file, 'r') as f:
         print(headways_avg)
         print(headways_std)
 
+        # plot speed average, std, trend
         fig = plt.figure(1)
-        fig.suptitle('Velocity', fontsize=16)
+        fig.suptitle('Velocity (m/s)', fontsize=16)
 
         lists = sorted(speeds_avg.items())
         t, avg = zip(*lists)
@@ -91,8 +144,9 @@ with open(rsu_data_file, 'r') as f:
 
         plt.legend()
 
+        # plot headways average, std, trend
         fig = plt.figure(2)
-        fig.suptitle('Headways', fontsize=16)
+        fig.suptitle('Headways (s)', fontsize=16)
 
         lists = sorted(headways_avg.items())
         t, avg = zip(*lists)
@@ -108,5 +162,53 @@ with open(rsu_data_file, 'r') as f:
         t, std = zip(*lists)
         plt.plot(t, std, 'r-', label="Standard Deviation")
 
+        plt.legend()
+
+        # plot fuel consumption average
+        fig = plt.figure(3)
+        fig.suptitle('Fuel Consumption (ml/s)', fontsize=16)
+
+        lists = sorted(fuel_consumption_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'r-', label="Fuel Consumption")
+        plt.legend()
+
+
+        # plot co2 emission average
+        fig = plt.figure(4)
+        fig.suptitle('CO2 Emissions (mg/s)', fontsize=16)
+        lists = sorted(co2_emission_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'b-', label="Carbon Dioxide")
+        plt.legend()
+
+        # plot co emission average
+        fig = plt.figure(5)
+        fig.suptitle('Carbon Monoxide (mg/s)', fontsize=16)
+        lists = sorted(co_emission_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'g-', label="Carbon Monoxide")
+        plt.legend()
+
+        # plot nox emission average
+        fig = plt.figure(6)
+        fig.suptitle('NOx Emissions (mg/s)', fontsize=16)
+        lists = sorted(nox_emission_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'm-', label="Nitrogen Oxides")
+        plt.legend()
+
+        # plot pmx emission average
+        fig = plt.figure(7)
+        fig.suptitle('Light-Duty Emissions (mg/s)', fontsize=16)
+        lists = sorted(pmx_emission_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'y-', label="Particular Matter")
+
+         # plot hc emission average
+        lists = sorted(pmx_emission_avg.items())
+        t, vals = zip(*lists)
+        plt.plot(t, vals, 'c-', label="HydroCarbons")
+                
         plt.legend()
         plt.show()

--- a/rl_fyp/ns3_logs/plot_vehicle_data.py
+++ b/rl_fyp/ns3_logs/plot_vehicle_data.py
@@ -14,6 +14,8 @@
 import sys
 import statistics
 import matplotlib.pylab as plt
+import numpy as np
+
 
 rsu_data_file = ''
 
@@ -24,7 +26,7 @@ if argumentList.__len__() < 2:
     exit(0)
 else:
     rsu_data_file = argumentList[1]
-    
+
 speeds_avg = {}
 speeds_std = {}
 headways_avg = {}
@@ -70,16 +72,22 @@ with open(rsu_data_file, 'r') as f:
         print(headways_avg)
         print(headways_std)
 
-        lists = sorted(speeds_avg.items())
-        t, avg = zip(*lists)
-
         fig = plt.figure(1)
         fig.suptitle('Velocity', fontsize=16)
-        plt.plot(t, avg, 'b-', label="Average")
+
+        lists = sorted(speeds_avg.items())
+        t, avg = zip(*lists)
+        plt.plot(t, avg, 'b-', label="Average/second")
+
+        t = t[100:]
+        avg = avg[100:]
+        pfit = np.polyfit(t, avg, 1)
+        trend_line_model = np.poly1d(pfit)
+        plt.plot(t, trend_line_model(t), "g--",  label="System Average Trend")
 
         lists = sorted(speeds_std.items())
         t, std = zip(*lists)
-        plt.plot(t, std, 'r--', label="Standard Deviation")
+        plt.plot(t, std, 'r-', label="Standard Deviation")
 
         plt.legend()
 
@@ -90,9 +98,15 @@ with open(rsu_data_file, 'r') as f:
         t, avg = zip(*lists)
         plt.plot(t, avg, 'b-', label="Average")
 
+        t = t[100:]
+        avg = avg[100:]
+        pfit = np.polyfit(t, avg, 1)
+        trend_line_model = np.poly1d(pfit)
+        plt.plot(t, trend_line_model(t), "g--",  label="System Average Trend")
+
         lists = sorted(headways_std.items())
         t, std = zip(*lists)
-        plt.plot(t, std, 'r--', label="Standard Deviation")
+        plt.plot(t, std, 'r-', label="Standard Deviation")
 
         plt.legend()
         plt.show()

--- a/rl_fyp/sumo_files/sumo_one_lane_highway/one_lane_highway.rou.xml
+++ b/rl_fyp/sumo_files/sumo_one_lane_highway/one_lane_highway.rou.xml
@@ -9,6 +9,6 @@
 		   		lcSpeedGainLookahead="0" lcCooperativeSpeed="0.1" lcPushy="0" impatience="0.5" minGap="0" tau="2.5"
 		   			probability="0.5" color="yellow"/>
 
-	<flow id="carflow" type="car" departLane="free" departSpeed="7.5" begin="1" end="30000" vehsPerHour="700.0" from="gneE1" to="gneE3" />
+	<flow id="carflow" type="car" departLane="free" departSpeed="7.5" begin="1" end="30000" vehsPerHour="1000.0" from="gneE1" to="gneE3" />
 
 </routes>

--- a/src/traci-applications/model/traffic-control-app.cc
+++ b/src/traci-applications/model/traffic-control-app.cc
@@ -254,11 +254,13 @@ RsuSpeedControl::ChangeSpeed ()
     {
 
       // print the initial content in the RSU map
-      NS_LOG_INFO ("RSU" << this->GetNode ()->GetId () << " table data = " << it->first
-                         << " :: " << (it->second).velocity << " :: " << (it->second).headway
-                         << " :: " << (it->second).lane_index << " :: " << (it->second).fuel_consumption
-                         << " :: " << (it->second).emission_co2 << " :: " << (it->second).emission_co2
-                         << " :: " << (it->second).emission_nox << " :: " << (it->second).emission_pmx);
+      NS_LOG_INFO (
+          "RSU" << this->GetNode ()->GetId () << " table data = " << it->first
+                << " :: " << (it->second).velocity << " :: " << (it->second).headway
+                << " :: " << (it->second).fuel_consumption << " :: " << (it->second).emission_co2
+                << " :: " << (it->second).emission_co << " :: " << (it->second).emission_nox
+                << " :: " << (it->second).emission_pmx << " :: " << (it->second).emission_hc
+                );
 
       // store speed and headway for each vehicle
       speeds.push_back ((it->second).velocity);
@@ -318,10 +320,11 @@ RsuSpeedControl::HandleRead (Ptr<Socket> socket)
     }
 
   // save vehicle data in struct (vehicle_id, speed, headway, lane_index, emission_co2 ....)
-  vehicle_data values = vehicle_data (
-      data[1], (double) std::stod (data[2]), (double) std::stod (data[3]),
-      (int) std::stoi (data[4]), (double) std::stod (data[5]), (double) std::stod (data[6]),
-      (double) std::stod (data[7]), (double) std::stod (data[8]), (double) std::stod (data[9]));
+  vehicle_data values = vehicle_data (data[1], (double) std::stod (data[2]),
+                                      (double) std::stod (data[3]), (int) std::stoi (data[4]),
+                                      (double) std::stod (data[5]), (double) std::stod (data[6]),
+                                      (double) std::stod (data[7]), (double) std::stod (data[8]),
+                                      (double) std::stod (data[9]), (double) std::stod (data[10]));
 
   // Inserting vehicle data to RSU database
   // using map iterator, find any matching id in the map
@@ -563,18 +566,20 @@ VehicleSpeedControl::Send ()
       << "*"
       << std::to_string (
              m_client->TraCIAPI::vehicle.getPMxEmission (m_client->GetVehicleId (this->GetNode ())))
+      << "*"
+      << std::to_string (
+             m_client->TraCIAPI::vehicle.getHCEmission (m_client->GetVehicleId (this->GetNode ())))
       << '\0';
   Ptr<Packet> packet = Create<Packet> ((uint8_t *) msg.str ().c_str (), msg.str ().length ());
 
   // send packet
   tx_socket->Send (packet);
-  NS_LOG_INFO (
-      "2 TX ***** Vehicle->RSU at time "
-      << Simulator::Now ().GetSeconds () << "s - "
-      << "[vehicle ip:" << ipAddr << "]"
-      << "[vehicle id:" << m_client->GetVehicleId (this->GetNode ()) << "]"
-      << "[tx vel:" << last_velocity << "m/s]"
-      << "[tx headway:" << last_headway << "s]\n");
+  NS_LOG_INFO ("2 TX ***** Vehicle->RSU at time "
+               << Simulator::Now ().GetSeconds () << "s - "
+               << "[vehicle ip:" << ipAddr << "]"
+               << "[vehicle id:" << m_client->GetVehicleId (this->GetNode ()) << "]"
+               << "[tx vel:" << last_velocity << "m/s]"
+               << "[tx headway:" << last_headway << "s]\n");
 
   ScheduleTransmit (m_interval);
 }

--- a/src/traci-applications/model/traffic-control-app.cc
+++ b/src/traci-applications/model/traffic-control-app.cc
@@ -204,14 +204,14 @@ RsuSpeedControl::Send ()
   while (it != m_vehicles_data.end ())
     {
       // Log new speeds
-      NS_LOG_INFO ("RSU" << this->GetNode ()->GetId () << "new data = " << it->first
+      NS_LOG_INFO ("RSU" << this->GetNode ()->GetId () << " new data = " << it->first
                          << " :: " << (it->second).velocity);
 
       // append vehicle id then new speed respectively
       msg << "|" << it->first << ":" << std::to_string ((it->second).velocity);
       it++;
     }
-
+    NS_LOG_INFO ("\n");
   // terminate message by appending '\0' character
   msg << '\0';
 

--- a/src/traci-applications/model/traffic-control-app.h
+++ b/src/traci-applications/model/traffic-control-app.h
@@ -24,6 +24,41 @@ class Packet;
 	 */
 
 /**
+ * \ingroup TrafficInfo
+	 * \brief A structure to hold vehicle related values
+	 *
+	 * THis structure saves vehicle related parameters such as speeds , headways and other emission related data.
+ */
+struct vehicel_data
+{
+
+  std::string vehicle_id; // id of vehicle
+  double speed; // vehicle speed m/s
+  double headway; // time to reach leading vehicle in s
+  int lane_index; // index of lane within road [1,2,..]
+  double fuel_consumption; // consumption of fuel
+  double emission_co2; // emmission of carbon dioxide
+  double emission_co; // emission of carbon monoxide
+  double emission_nox; // emission of nitrogen oxides
+  double emission_pmx; // emission of particulate matter
+
+  vehicel_data (std::string _vehicle_id, double _speed, double _headway, int _lane_index,
+                double _fuel_consumption, double _emission_co2, double _emission_co,
+                double _emission_nox, double _emission_pmx)
+  {
+    vehicle_id = _vehicle_id;
+    speed = _speed;
+    headway = _headway;
+    lane_index = _lane_index;
+    fuel_consumption = _fuel_consumption;
+    emission_co2 = _emission_co2;
+    emission_co = _emission_co;
+    emission_nox = _emission_nox;
+    emission_pmx = _emission_pmx;
+  }
+};
+
+/**
 	 * \ingroup TrafficInfo
 	 * \brief A Traffic Info server
 	 *
@@ -120,10 +155,6 @@ private:
   Ptr<TraciClient> m_client;
   double last_velocity;
   double last_headway;
-
-  double m_desired_speed = 40;
-  double m_speed_delta = 15;
-  double m_desired_headway = 2.0;
 };
 
 } // namespace ns3

--- a/src/traci-applications/model/traffic-control-app.h
+++ b/src/traci-applications/model/traffic-control-app.h
@@ -29,11 +29,11 @@ class Packet;
 	 *
 	 * THis structure saves vehicle related parameters such as speeds , headways and other emission related data.
  */
-struct vehicel_data
+struct vehicle_data
 {
 
   std::string vehicle_id; // id of vehicle
-  double speed; // vehicle speed m/s
+  double velocity; // vehicle velocity m/s
   double headway; // time to reach leading vehicle in s
   int lane_index; // index of lane within road [1,2,..]
   double fuel_consumption; // consumption of fuel
@@ -42,12 +42,12 @@ struct vehicel_data
   double emission_nox; // emission of nitrogen oxides
   double emission_pmx; // emission of particulate matter
 
-  vehicel_data (std::string _vehicle_id, double _speed, double _headway, int _lane_index,
+  vehicle_data (std::string _vehicle_id, double _velocity, double _headway, int _lane_index,
                 double _fuel_consumption, double _emission_co2, double _emission_co,
                 double _emission_nox, double _emission_pmx)
   {
     vehicle_id = _vehicle_id;
-    speed = _speed;
+    velocity = _velocity;
     headway = _headway;
     lane_index = _lane_index;
     fuel_consumption = _fuel_consumption;
@@ -105,7 +105,7 @@ private:
   Ptr<Socket> rx_socket; //!< IPv4 Socket
   EventId m_sendEvent; //!< Event to send the next packet
   Ptr<TraciClient> m_client;
-  std::map<std::string, std::pair<double, double>> m_vehicles_data;
+  std::map<std::string, vehicle_data> m_vehicles_data;
 
   /// Callbacks for tracing the packet Tx events
   TracedCallback<Ptr<const Packet>> m_txTrace;

--- a/src/traci-applications/model/traffic-control-app.h
+++ b/src/traci-applications/model/traffic-control-app.h
@@ -41,10 +41,11 @@ struct vehicle_data
   double emission_co; // emission of carbon monoxide
   double emission_nox; // emission of nitrogen oxides
   double emission_pmx; // emission of particulate matter
+  double emission_hc; // emission of hydrocarbon
 
   vehicle_data (std::string _vehicle_id, double _velocity, double _headway, int _lane_index,
                 double _fuel_consumption, double _emission_co2, double _emission_co,
-                double _emission_nox, double _emission_pmx)
+                double _emission_nox, double _emission_pmx, double _emission_hc)
   {
     vehicle_id = _vehicle_id;
     velocity = _velocity;
@@ -55,6 +56,7 @@ struct vehicle_data
     emission_co = _emission_co;
     emission_nox = _emission_nox;
     emission_pmx = _emission_pmx;
+    emission_hc = _emission_hc;
   }
 };
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
RSU logs show speed and headway average values per time unit per RSU and standard deviation of these samples  


* **What is the new behavior (if this is a feature change)?**
Added the feature of collecting  and plotting the following (all are averages per time unit): 
 1- fuel consumption
 2- co2 emission
 3- co emission
 4- nox emission (nitrogen oxides)
 5- pmx emission (particular matter)
 6- hc emission (hydrocarbons)
also added trend plot for headways and velocities

In addition, the rsu now saves all these data and the lane index for each vehicle per timestep

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users shall not change anything


* **Files Affected**:
rl_fyp/ns3_logs/plot_vehicle_data.py
src/traci-applications/model/traffic-control-app.cc
